### PR TITLE
fix: update auto-merge-sandbox workflow

### DIFF
--- a/.github/workflows/auto-merge-sandbox.yml
+++ b/.github/workflows/auto-merge-sandbox.yml
@@ -5,18 +5,32 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto-merge:
     name: Auto Merge
     if: github.event.label.name == 'to-stage'
     runs-on: ubuntu-latest
     steps:
-      - name: automerge
-        uses: "pascalgn/automerge-action@v0.16.4"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: "to-stage"
-          MERGE_METHOD: "merge"
-          MERGE_COMMIT_MESSAGE: "Auto-merged PR to sandbox after 'to-stage' label"
-          MERGE_RETRIES: "6"
-          MERGE_RETRY_SLEEP: "10000"
+      - name: Checkout sandbox branch
+        uses: actions/checkout@v4
+        with:
+          ref: sandbox
+          fetch-depth: 0
+
+      - name: Merge PR branch into sandbox
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          echo "Fetching PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          
+          echo "Merging into sandbox"
+          git merge ${{ github.event.pull_request.head.sha }} --no-ff -m "Auto-merge PR #${{ github.event.pull_request.number }} into sandbox"
+          
+          echo "Pushing to origin sandbox"
+          git push origin sandbox

--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # A1 French Classes
 Website where students can learn French from the best teachers across the world, they can add subscriptions and reoccurring payments for the services.
-
-testing gha

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # A1 French Classes
 Website where students can learn French from the best teachers across the world, they can add subscriptions and reoccurring payments for the services.
+
+testing gha


### PR DESCRIPTION
This PR fixes the `Auto Merge to Sandbox` workflow. It replaces the `automerge-action` (which targets the PR base branch) with a custom script that specifically merges the PR head branch into the `sandbox` branch when the `to-stage` label is added.

Note: Since the `sandbox` branch is likely protected, this action will also need to be allowed to push to that branch (or we may need to use a PAT/App Token with bypass permissions).